### PR TITLE
Drop support for Node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 17.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Add new [`executeOne`](README.md#executeone) and [`executeMaybeOne`](README.md#executeMaybeOne) functions as the duals
   of [`queryOne`](README.md#queryOne) and [`queryMaybeOne`](README.md#queryMaybeOne). They will throw a `ResultError` 
   if the query modifies different than the expected amount of rows.
+
+### Changed
+
+- Drop support for Node 12.x
 
 ## [0.12.0] - 2022-03-30
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "transaction"
   ],
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "files": [
     "dist"


### PR DESCRIPTION
- Drop support for Node 12.x
- Replace Node 17.x on CI with Node 18.x
